### PR TITLE
Remind devs to name PR with npm-publish trigger phrase

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## MADiE PR
+
+### IF THIS IS A RELASE, PR MUST BE NAMED `Release x.y.z`, where x.y.z is the new version
+
+Jira Ticket: [MAT-0000](https://jira.cms.gov/browse/MAT-0000)
+(Optional) Related Tickets:
+
+### Summary
+
+### All Submissions
+* [ ] This PR has the JIRA linked.
+* [ ] Required tests are included.
+* [ ] No extemporaneous files are included (i.e Complied files or testing results).
+* [ ] This PR is merging into the **correct branch**.
+* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
+* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.
+
+### DevSecOps
+If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.
+
+* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
+* [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).
+
+### Reviewers
+By Approving this PR you are attesting to the following:
+
+*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
+*  The tests appropriately test the new code, including edge cases.
+*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.


### PR DESCRIPTION
The npm-publish action is triggered by a commit containing the phrase "Release x.y.z" where x.y.z is the new version.

Either the developer can include such a commit, or, most often, name the PR "Release x.y.z" so that the resulting merge commit message contains the trigger phrase.