### PR TITLE
Release 1.4.73

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@madie/madie-models",
-  "version": "1.4.72",
+  "version": "1.4.73",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@madie/madie-models",
-      "version": "1.4.72",
+      "version": "1.4.73",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^27.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@madie/madie-models",
-  "version": "1.4.72",
+  "version": "1.4.73",
   "description": "Models for MADiE Project",
   "scripts": {
     "build": "tsc",

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -44,3 +44,13 @@ export function getModelShortName(model: string): string {
 export function isFhirModel(model: string | undefined | null): boolean {
   return Boolean(model) && model !== Model.QDM_5_6;
 }
+
+/**
+ * Returns the model family used in export artifact names: "FHIR" for QI-Core
+ * models, otherwise the first word of the model name (e.g. "QDM").
+ */
+export function getModelFamily(model: string) {
+  if (model) {
+    return model.startsWith("QI-Core") ? `FHIR` : `${model.split(" ")[0]}`;
+  }
+}

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -49,7 +49,7 @@ export function isFhirModel(model: string | undefined | null): boolean {
  * Returns the model family used in export artifact names: "FHIR" for QI-Core
  * models, otherwise the first word of the model name (e.g. "QDM").
  */
-export function getModelFamily(model: string) {
+export function getModelFamily(model: string): string | undefined {
   if (model) {
     return model.startsWith("QI-Core") ? `FHIR` : `${model.split(" ")[0]}`;
   }

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -46,11 +46,11 @@ export function isFhirModel(model: string | undefined | null): boolean {
 }
 
 /**
- * Returns the model family used in export artifact names: "FHIR" for QI-Core
- * models, otherwise the first word of the model name (e.g. "QDM").
+ * Returns the model family used in export artifact names: "QDM" for QDM models,
+ * "FHIR" for every FHIR-based model (QI-Core, US-Core, US Quality Core).
  */
 export function getModelFamily(model: string): string | undefined {
   if (model) {
-    return model.startsWith("QI-Core") ? `FHIR` : `${model.split(" ")[0]}`;
+    return isFhirModel(model) ? "FHIR" : "QDM";
   }
 }

--- a/src/__tests__/Model.test.ts
+++ b/src/__tests__/Model.test.ts
@@ -51,18 +51,16 @@ test("isFhirModel returns false for QDM and empty/falsy values", () => {
   expect(isFhirModel(undefined)).toBe(false);
 });
 
-test("getModelFamily returns FHIR for QI-Core models", () => {
+test("getModelFamily returns FHIR for every FHIR-based model", () => {
   expect(getModelFamily(Model.QICORE)).toBe("FHIR");
   expect(getModelFamily(Model.QICORE_6_0_0)).toBe("FHIR");
-  expect(getModelFamily("QI-Core v5.0.000")).toBe("FHIR");
+  expect(getModelFamily(Model.FHIR_4_0_1)).toBe("FHIR");
+  expect(getModelFamily(Model.US_CORE_6_1_0)).toBe("FHIR");
+  expect(getModelFamily(Model.US_QUALITY_0_5_0)).toBe("FHIR");
 });
 
-test("getModelFamily returns the first word of the model name otherwise", () => {
+test("getModelFamily returns QDM for QDM models", () => {
   expect(getModelFamily(Model.QDM_5_6)).toBe("QDM");
-  expect(getModelFamily("QDM v4.0.000")).toBe("QDM");
-  // Note: intentionally NOT the same as isFhirModel — US Quality Core is
-  // FHIR-based but its export artifact family is the first word, "US".
-  expect(getModelFamily(Model.US_QUALITY_0_5_0)).toBe("US");
 });
 
 test("getModelFamily returns undefined for empty model", () => {

--- a/src/__tests__/Model.test.ts
+++ b/src/__tests__/Model.test.ts
@@ -1,4 +1,10 @@
-import { Model, MODEL_SHORT_NAMES, getModelShortName, isFhirModel } from "../Model";
+import {
+  Model,
+  MODEL_SHORT_NAMES,
+  getModelShortName,
+  isFhirModel,
+  getModelFamily,
+} from "../Model";
 
 test("Verifies that Model has the correct attributes", () => {
   expect(Model.QICORE.valueOf()).toEqual("QI-Core v4.1.1");
@@ -25,7 +31,9 @@ test("getModelShortName returns correct shortNames", () => {
 });
 
 test("getModelShortName throws for an unknown model string", () => {
-  expect(() => getModelShortName("Unknown Model v1.0")).toThrow("Unknown model");
+  expect(() => getModelShortName("Unknown Model v1.0")).toThrow(
+    "Unknown model"
+  );
 });
 
 test("isFhirModel returns true for all non-QDM models", () => {
@@ -41,4 +49,22 @@ test("isFhirModel returns false for QDM and empty/falsy values", () => {
   expect(isFhirModel(Model.QDM_5_6)).toBe(false);
   expect(isFhirModel("")).toBe(false);
   expect(isFhirModel(undefined)).toBe(false);
+});
+
+test("getModelFamily returns FHIR for QI-Core models", () => {
+  expect(getModelFamily(Model.QICORE)).toBe("FHIR");
+  expect(getModelFamily(Model.QICORE_6_0_0)).toBe("FHIR");
+  expect(getModelFamily("QI-Core v5.0.000")).toBe("FHIR");
+});
+
+test("getModelFamily returns the first word of the model name otherwise", () => {
+  expect(getModelFamily(Model.QDM_5_6)).toBe("QDM");
+  expect(getModelFamily("QDM v4.0.000")).toBe("QDM");
+  // Note: intentionally NOT the same as isFhirModel — US Quality Core is
+  // FHIR-based but its export artifact family is the first word, "US".
+  expect(getModelFamily(Model.US_QUALITY_0_5_0)).toBe("US");
+});
+
+test("getModelFamily returns undefined for empty model", () => {
+  expect(getModelFamily("")).toBeUndefined();
 });


### PR DESCRIPTION
## MADiE PR

Add getModelFamily(model) to Model.ts as the single copy consumed by madie-util (export flow) and madie-measure

### IF THIS IS A RELASE, PR MUST BE NAMED `Release x.y.z`, where x.y.z is the new version

Jira Ticket: [MAT-9813](https://jira.cms.gov/browse/MAT-9813), [MAT-9814](https://jira.cms.gov/browse/MAT-9814)
(Optional) Related Tickets:

https://github.com/MeasureAuthoringTool/madie-util/pull/217
https://github.com/MeasureAuthoringTool/madie-admin/pull/48/
https://github.com/MeasureAuthoringTool/madie-measure/pull/1610

### Summary

### All Submissions

- [ ] This PR has the JIRA linked.
- [ ] Required tests are included.
- [ ] No extemporaneous files are included (i.e Complied files or testing results).
- [ ] This PR is merging into the **correct branch**.
- [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
- [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps

If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

- [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).
- [ ] All CDN/Web dependencies are hosted internally (i.e MADiE-Root Repo).

### Reviewers

By Approving this PR you are attesting to the following:

- Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
- The tests appropriately test the new code, including edge cases.
- If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
